### PR TITLE
fix(e2e): reload-poll tx-gated CTAs in lifecycle spec

### DIFF
--- a/e2e/specs/lifecycle.e2e.spec.ts
+++ b/e2e/specs/lifecycle.e2e.spec.ts
@@ -110,7 +110,13 @@ test.describe("Full RFQ lifecycle @tx", () => {
     });
 
     // --- Taker1: settle -----------------------------------------------------
+    // The CTA needs fresh reads of BOTH the rfq (Selected) and the quote
+    // (selected flag): right after select_quote a lagging RPC node can serve
+    // stale bytes on the initial load, and guards only re-evaluate on render.
+    // Reload-poll like the reveal/select steps; 120s stays far inside the
+    // 600s funding window so a genuine failure still surfaces fast.
     await taker1Page.goto(rfqUrl);
+    await waitForActionWindow(taker1Page, "Settle now", 120_000);
     await taker1Page.getByRole("button", { name: "Settle now" }).click();
     // Same label pattern as reveal: the action bar navigates to the settle
     // cockpit, which hosts its own "Settle now" submit.
@@ -121,14 +127,20 @@ test.describe("Full RFQ lifecycle @tx", () => {
     });
 
     // --- Settled panel shows the REAL traded amount (regression) -----------
+    // Same read-propagation lag applies to the freshly settled state.
     await makerPage.goto(rfqUrl);
-    await expect(makerPage.getByRole("heading", { name: "Settlement complete" })).toBeVisible({
-      timeout: 30_000,
-    });
+    await expect(async () => {
+      await makerPage.reload();
+      await expect(makerPage.getByRole("heading", { name: "Settlement complete" })).toBeVisible({
+        timeout: 10_000,
+      });
+    }).toPass({ timeout: 120_000, intervals: [5_000] });
     await expect(makerPage.getByText(committedAmount, { exact: false })).toBeVisible();
 
     // --- Taker2 (reward recipient): claim the fee share --------------------
+    // The claim CTA hangs off settlement.completed_at — same lag, same poll.
     await taker2Page.goto(rfqUrl);
+    await waitForActionWindow(taker2Page, "Claim reward", 120_000);
     await taker2Page.getByRole("button", { name: "Claim reward" }).click();
     await taker2Page.getByRole("dialog").getByRole("button", { name: "Claim reward" }).click();
     await expect(taker2Page.getByText("Reward claimed to your wallet")).toBeVisible({


### PR DESCRIPTION
## Why

The first post-merge `@tx` lifecycle run on `main` ([28655340947](https://github.com/unleaktrade/app/actions/runs/28655340947)) failed on a test-determinism flake, not a product regression — the identical code had passed the same workflow 27 minutes earlier on the PR-#32 head. Right after the maker's `select_quote` transaction, the taker's page can load stale account bytes from a lagging devnet RPC node; the "Settle now" CTA needs fresh reads of **both** the RFQ (`Selected`) and the quote (`selected` flag), and guards only re-evaluate on render. The spec's settle step did a single `goto` + unbounded click, so a stale initial read left the page without the CTA forever and the test idled until its 20-minute budget expired. The taker2 "Claim reward" step had the same single-`goto` pattern.

## Fix

Apply the file's own established `waitForActionWindow` reload-poll pattern (already used for the reveal and select windows, `e2e/helpers/rfq.ts`) to the two tx-gated CTAs — settle (120s bound, well inside the 600s funding window) and claim — plus the same reload-poll for the maker's post-settlement panel check. No assertions weakened; a genuine failure now surfaces within the bounded window instead of a silent 20-minute hang.

## Verification

- `npm run typecheck` clean · `npm run lint` 0 errors / 5 pre-existing warnings · `npm test` 167 passing · all 13 hermetic read-only e2e specs green
- Live devnet: the full `@tx` lifecycle (draft → open → commit → reveal → select → settle → claim) is **green on this exact commit** — [run 28658338398](https://github.com/unleaktrade/app/actions/runs/28658338398)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVSbGYJaigd9NCnUX1Y4Bf

---
_Generated by [Claude Code](https://claude.ai/code/session_01AVSbGYJaigd9NCnUX1Y4Bf)_