### PR TITLE
docs: point Figma design file link at the populated file (#21)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ Goals the stack has to deliver:
 - **#13–#15** — Phases 3–5 (maker / taker / facilitator instruction wiring) — shipped on the PR-#32 branch
 - **#17** — tests & CI
 - **#18** — docs (includes a README rewrite)
-- **#21** — Figma design file as the visual source of truth: https://www.figma.com/design/vmyQPE8WnUX4a5JEl6C2BA
+- **#21** — Figma design file as the visual source of truth: https://www.figma.com/design/ywVePMypIpifiUMA9auaMs
 
 Re-read the linked issues before starting substantive work.
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ switchers. Rewards and fees are always denominated in the RFQ's quote token,
 never aggregated into USD.
 
 Visual source of truth: the
-[Figma design file](https://www.figma.com/design/vmyQPE8WnUX4a5JEl6C2BA)
+[Figma design file](https://www.figma.com/design/ywVePMypIpifiUMA9auaMs)
 (issue #21).
 
 ## Companion repositories


### PR DESCRIPTION
Updates the Figma design-file link in `README.md` and `CLAUDE.md` to the populated file: https://www.figma.com/design/ywVePMypIpifiUMA9auaMs

The file originally referenced by issue #21 (`vmyQPE8WnUX4a5JEl6C2BA`) is read-only for the connected account, so the full code→design build (tokens, component library, all screens) went into a fresh file in the TRENDEV org — see the build summary on #21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBGYZEpWMTS8DzRWT7ATP6

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBGYZEpWMTS8DzRWT7ATP6)_