### PR TITLE
fix(liquidity-guard): reach the upstream in production builds

### DIFF
--- a/src/chain/liquidityGuard.ts
+++ b/src/chain/liquidityGuard.ts
@@ -1,23 +1,32 @@
 // Client for the liquidity-guard attestation service.
 //
-// All requests go through the Vite dev-server proxy at /liquidity-guard/* so
-// the browser sees same-origin in dev. In production the service must be
-// reachable same-origin or a CORS-enabled reverse proxy must be deployed —
-// the upstream Rust service at ../liquidity-guard sets no CORS headers.
+// In dev, requests go through the Vite dev-server proxy at /liquidity-guard/*
+// so the browser sees same-origin (see vite.config.ts server.proxy). In a
+// production build there is no dev server, so we call the upstream Heroku
+// instance directly — the Rust service at ../liquidity-guard now serves
+// permissive CORS (allow_any_origin), which makes the cross-origin call safe.
 
 import type { PublicKey } from "@solana/web3.js";
 import type { WalletContextState } from "@solana/wallet-adapter-react";
 import nacl from "tweetnacl";
 import type { Cluster } from "@/chain/env";
 
-// Each cluster has its own liquidity-guard upstream, proxied under a dedicated
-// path (configured in vite.config.ts). We route by the active cluster so a
-// devnet session hits the devnet guard, mainnet hits mainnet, etc.
+// Resolved per-cluster upstream URLs, injected at build time by vite.config.ts
+// (env overrides merged over the Heroku defaults). Public, keyless URLs.
+declare const __LG_TARGETS__: Record<"localnet" | "devnet" | "mainnet", string>;
+
+// Each cluster has its own liquidity-guard upstream. We route by the active
+// cluster so a devnet session hits the devnet guard, mainnet hits mainnet, etc.
 const BASE_PATH = "/liquidity-guard";
 
 function lgUrl(cluster: Cluster, endpoint: "health" | "check"): string {
   const segment = cluster === "mainnet-beta" ? "mainnet" : cluster;
-  return `${BASE_PATH}/${segment}/${endpoint}`;
+  // Dev: same-origin proxy path. Prod: absolute upstream (no proxy exists).
+  if (import.meta.env.DEV) {
+    return `${BASE_PATH}/${segment}/${endpoint}`;
+  }
+  const target = __LG_TARGETS__[segment].replace(/\/$/, "");
+  return `${target}/${endpoint}`;
 }
 
 export interface AttestationRequest {
@@ -65,7 +74,11 @@ function fromHex(hex: string): Uint8Array {
   if (hex.length % 2 !== 0) throw new Error(`hex string has odd length: ${hex.length}`);
   const out = new Uint8Array(hex.length / 2);
   for (let i = 0; i < out.length; i += 1) {
-    out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+    const byte = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+    // Guard malformed hex: parseInt returns NaN, which would silently coerce to
+    // a 0 byte and misattribute a later commit-hash / signature mismatch.
+    if (Number.isNaN(byte)) throw new Error(`invalid hex at offset ${i * 2}`);
+    out[i] = byte;
   }
   return out;
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,11 +22,15 @@ function loadDevWallets(dir: string | undefined): { label: string; secretKey: nu
     }));
 }
 
-// liquidity-guard upstreams per Solana cluster. The service sets no CORS
-// headers, so in dev every cluster is proxied through the dev server (same
-// origin). The proxy is static (set at server start) while the cluster is a
-// runtime choice, so we expose ONE path per cluster (/liquidity-guard/<cluster>)
-// and let the client pick the path — see src/chain/liquidityGuard.ts.
+// liquidity-guard upstreams per Solana cluster. In dev every cluster is proxied
+// through the dev server (same origin) so the browser never makes a cross-origin
+// call while iterating. The proxy is static (set at server start) while the
+// cluster is a runtime choice, so we expose ONE path per cluster
+// (/liquidity-guard/<cluster>) and let the client pick the path. In production
+// there is no dev server, so the client calls the upstream directly — the Rust
+// service now serves permissive CORS (allow_any_origin), which makes the
+// cross-origin call safe. The resolved map is handed to the client verbatim via
+// the __LG_TARGETS__ define below — see src/chain/liquidityGuard.ts.
 // Defaults below can be overridden per env via VITE_LG_URL_{LOCALNET,DEVNET,MAINNET}.
 const LG_DEFAULTS = {
   localnet: "http://localhost:8080",
@@ -65,6 +69,10 @@ export default defineConfig(({ mode, command }) => {
     define: {
       global: "globalThis",
       __DEV_WALLETS__: JSON.stringify(devWallets),
+      // Resolved liquidity-guard upstreams, exposed to the client so a
+      // production build (no dev proxy) can call the upstream directly. These
+      // are public, keyless URLs — safe to inline into the bundle.
+      __LG_TARGETS__: JSON.stringify(lgTarget),
     },
     optimizeDeps: {
       include: ["buffer", "process"],
@@ -132,9 +140,9 @@ export default defineConfig(({ mode, command }) => {
     server: {
       port: 3000,
       open: true,
-      // One proxy path per cluster; the client routes to the matching one.
-      // Production (no dev server) needs same-origin hosting or a CORS-enabled
-      // reverse proxy per cluster — out of scope here.
+      // One proxy path per cluster; the client routes to the matching one in
+      // dev. Production has no dev server, so the client calls the upstream
+      // directly via __LG_TARGETS__ (the service serves permissive CORS).
       proxy: {
         "/liquidity-guard/localnet": lgProxy("localnet", lgTarget.localnet),
         "/liquidity-guard/devnet": lgProxy("devnet", lgTarget.devnet),


### PR DESCRIPTION
## Problem

`lgUrl()` always returned the same-origin relative path `/liquidity-guard/<cluster>/<endpoint>`. That proxy only exists under the Vite dev server (`server.proxy`); a production `vite build` (GitHub Pages) has no such route, so the browser hits the SPA 404 fallback (HTML) and `res.json()` throws. **This broke `commit_quote`'s attestation call and the `HealthPill` `/health` ping on the live host** (`app.unleak.trade`).

## Fix

- Expose the already-resolved per-cluster upstream map (env overrides merged over the Heroku defaults) to the client via a `__LG_TARGETS__` define — same pattern as `__DEV_WALLETS__`.
- `lgUrl()` branches on `import.meta.env.DEV`: same-origin proxy in dev (no CORS, keeps dev-server routing), absolute upstream in prod. The Rust service now serves permissive CORS (`allow_any_origin`), so the cross-origin call is safe; the URLs are public + keyless, so inlining them does not violate the "no secrets in `VITE_*`" rule.
- Refresh the stale "sets no CORS headers" comments in both files.
- Drive-by: guard `fromHex` against malformed hex (`NaN` was silently coercing to a `0` byte, misattributing a later commit-hash/signature mismatch).

## Verification

- `npm run typecheck` clean · `npm run lint` at baseline (5 warnings/0 errors) · `npm test` 245/245.
- Production bundle grep confirms `lgUrl` resolves to `https://liquidity-guard-{devnet,mainnet}-…herokuapp.com/${endpoint}` (DEV branch tree-shaken out).
- Upstream reachable + CORS-permissive: devnet/mainnet `/health` → `200`, `Access-Control-Allow-Origin: *`, `service_pubkey` matches on-chain Config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)