### PR TITLE
perf: code-split the bundle (route-lazy + vendor chunks)

### DIFF
--- a/scripts/bundle-budget.json
+++ b/scripts/bundle-budget.json
@@ -1,5 +1,6 @@
 {
-  "comment": "Gzip budgets for build/assets JS, enforced by check-bundle-size.mjs in CI. Baseline 2026-07-04: single entry chunk at 571.7 kB gzip (web3.js + Anchor + recharts dominate). Budgets are baseline +10% — raise deliberately in a PR when a dependency legitimately grows the bundle.",
-  "entryGzipKb": 630,
-  "totalJsGzipKb": 645
+  "comment": "Gzip budgets for build/assets JS, enforced by check-bundle-size.mjs in CI. Baseline 2026-07-05 (post code-split): entry shell 101.5 kB, initial load (entry + modulepreloads = first-paint JS) 552.9 kB, total 591.2 kB. web3.js + Anchor (vendor-solana, eager) and recharts (vendor-charts, warmed for the landing chart) dominate initial load; the 5 route-lazy screens + html-to-image/qrcode defer. Budgets are baseline + headroom — raise deliberately in a PR when a dependency legitimately grows the bundle.",
+  "entryGzipKb": 130,
+  "initialLoadGzipKb": 580,
+  "totalJsGzipKb": 615
 }

--- a/scripts/check-bundle-size.mjs
+++ b/scripts/check-bundle-size.mjs
@@ -48,6 +48,17 @@ try {
 const entryMatch = indexHtml.match(/src="\/?(assets\/[^"]+\.js)"/);
 const entryName = entryMatch?.[1]?.replace(/^assets\//, "") ?? null;
 
+// "Initial load" = the entry chunk plus every chunk index.html preloads
+// (rel="modulepreload"). This is what the browser actually fetches on first
+// paint, so it's the honest gate post-code-splitting: route-lazy chunks (and
+// their unique deps) are NOT preloaded, so they don't count here.
+const preloadNames = new Set(
+  [...indexHtml.matchAll(/rel="modulepreload"[^>]*href="\/?(assets\/[^"]+\.js)"/g)].map((m) =>
+    m[1].replace(/^assets\//, ""),
+  ),
+);
+if (entryName) preloadNames.add(entryName);
+
 const gzipKb = (path) => Math.round((gzipSync(readFileSync(path)).length / 1024) * 10) / 10;
 const rawKb = (path) => Math.round((statSync(path).size / 1024) * 10) / 10;
 
@@ -61,9 +72,12 @@ const jsRows = js.map((f) => ({
   rawKb: rawKb(join(assetsDir, f)),
   gzipKb: gzipKb(join(assetsDir, f)),
   entry: f === entryName,
+  initial: preloadNames.has(f),
 }));
 
 const entryGzipKb = jsRows.filter((r) => r.entry).reduce((a, r) => a + r.gzipKb, 0);
+const initialLoadGzipKb =
+  Math.round(jsRows.filter((r) => r.initial).reduce((a, r) => a + r.gzipKb, 0) * 10) / 10;
 const totalJsGzipKb = Math.round(jsRows.reduce((a, r) => a + r.gzipKb, 0) * 10) / 10;
 const cssGzipKb = Math.round(css.reduce((a, f) => a + gzipKb(join(assetsDir, f)), 0) * 10) / 10;
 const fontsRawKb = Math.round(fonts.reduce((a, f) => a + rawKb(join(assetsDir, f)), 0) * 10) / 10;
@@ -73,6 +87,11 @@ if (entryName === null) breaches.push("Could not identify the entry chunk from b
 if (entryGzipKb > budget.entryGzipKb) {
   breaches.push(`Entry chunk ${entryGzipKb} kB gzip exceeds budget ${budget.entryGzipKb} kB`);
 }
+if (budget.initialLoadGzipKb != null && initialLoadGzipKb > budget.initialLoadGzipKb) {
+  breaches.push(
+    `Initial load ${initialLoadGzipKb} kB gzip exceeds budget ${budget.initialLoadGzipKb} kB`,
+  );
+}
 if (totalJsGzipKb > budget.totalJsGzipKb) {
   breaches.push(`Total JS ${totalJsGzipKb} kB gzip exceeds budget ${budget.totalJsGzipKb} kB`);
 }
@@ -80,12 +99,17 @@ if (totalJsGzipKb > budget.totalJsGzipKb) {
 const summary = {
   entryChunk: entryName,
   entryGzipKb,
+  initialLoadGzipKb,
   totalJsGzipKb,
   cssGzipKb,
   fontsRawKb,
   budget,
   headroom: {
     entryKb: Math.round((budget.entryGzipKb - entryGzipKb) * 10) / 10,
+    initialLoadKb:
+      budget.initialLoadGzipKb != null
+        ? Math.round((budget.initialLoadGzipKb - initialLoadGzipKb) * 10) / 10
+        : null,
     totalJsKb: Math.round((budget.totalJsGzipKb - totalJsGzipKb) * 10) / 10,
   },
   breaches,
@@ -101,6 +125,11 @@ if (asJson) {
   console.log(
     `| Entry chunk | ${entryGzipKb} kB | ${budget.entryGzipKb} kB | ${summary.headroom.entryKb} kB |`,
   );
+  if (budget.initialLoadGzipKb != null) {
+    console.log(
+      `| Initial load (entry + preloads) | ${initialLoadGzipKb} kB | ${budget.initialLoadGzipKb} kB | ${summary.headroom.initialLoadKb} kB |`,
+    );
+  }
   console.log(
     `| Total JS | ${totalJsGzipKb} kB | ${budget.totalJsGzipKb} kB | ${summary.headroom.totalJsKb} kB |`,
   );
@@ -112,6 +141,11 @@ if (asJson) {
   }
 } else {
   console.log(`Entry chunk (${entryName}): ${entryGzipKb} kB gzip (budget ${budget.entryGzipKb})`);
+  if (budget.initialLoadGzipKb != null) {
+    console.log(
+      `Initial load (entry + preloads): ${initialLoadGzipKb} kB gzip (budget ${budget.initialLoadGzipKb})`,
+    );
+  }
   console.log(`Total JS: ${totalJsGzipKb} kB gzip (budget ${budget.totalJsGzipKb})`);
   console.log(`CSS: ${cssGzipKb} kB gzip · Fonts: ${fontsRawKb} kB raw (informational)`);
   for (const row of jsRows.sort((a, b) => b.gzipKb - a.gzipKb).slice(0, 10)) {

--- a/src/app/components/Marketplace.tsx
+++ b/src/app/components/Marketplace.tsx
@@ -1,5 +1,5 @@
 import { motion } from "motion/react";
-import { useMemo, useState } from "react";
+import { lazy, Suspense, useMemo, useState } from "react";
 import { useWallet } from "@solana/wallet-adapter-react";
 import type { RFQ } from "@/types/rfq";
 import { useRfqAccounts } from "@/chain/accounts/lists";
@@ -29,7 +29,6 @@ import { EmptyState } from "@/app/components/EmptyState";
 import { RadarIllustration } from "@/app/components/illustrations";
 import { ErrorRetry } from "@/app/components/ErrorRetry";
 import { MarketStatsCards } from "@/app/components/marketplace/MarketStatsCards";
-import { OpenInterestByToken } from "@/app/components/marketplace/OpenInterestByToken";
 import { MarketOverview } from "@/app/components/marketplace/MarketOverview";
 import {
   Search,
@@ -49,6 +48,14 @@ import {
   BadgeCheck,
   Edit3,
 } from "lucide-react";
+
+// Lazy so recharts (its only other importer, RewardsSection, is on the lazy
+// My-Activity route) stays out of the entry chunk — see routes.tsx / A2.
+const OpenInterestByToken = lazy(() =>
+  import("@/app/components/marketplace/OpenInterestByToken").then((m) => ({
+    default: m.OpenInterestByToken,
+  })),
+);
 
 interface MarketplaceProps {
   onQuoteRFQ: (rfq: RFQ) => void;
@@ -190,7 +197,11 @@ export function Marketplace({ onQuoteRFQ, onViewRFQ, onEditRFQ }: MarketplacePro
 
       {/* Analytics Section */}
       <div className="grid lg:grid-cols-[320px_1fr] gap-4 sm:gap-6 mb-6 sm:mb-8">
-        <OpenInterestByToken buckets={stats.openByQuoteMint} />
+        <Suspense
+          fallback={<div className="skeleton-shimmer h-[220px] rounded-2xl" aria-hidden="true" />}
+        >
+          <OpenInterestByToken buckets={stats.openByQuoteMint} />
+        </Suspense>
         <MarketOverview stats={stats} now={nowSecs} />
       </div>
 

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -1,15 +1,22 @@
+import type { ComponentType } from "react";
 import { createBrowserRouter, Navigate } from "react-router";
 import { useAuth } from "@/app/providers/AuthProvider";
 import { WalletConnect } from "@/app/components/WalletConnect";
 import { AuthGate } from "@/app/components/AuthGate";
 import { DashboardLayout } from "@/app/components/DashboardLayout";
 import { MarketplaceWrapper } from "@/app/components/MarketplaceWrapper";
-import { MyActivity } from "@/app/components/MyActivity";
-import { Transparency } from "@/app/components/Transparency";
-import { RFQDetailWrapper } from "@/app/components/RFQDetailWrapper";
-import { RevealQuoteWrapper } from "@/app/components/RevealQuoteWrapper";
-import { SettleQuoteWrapper } from "@/app/components/SettleQuoteWrapper";
-import { ComponentStories } from "@/app/components/ComponentStories";
+
+// The shell (DashboardLayout) and the index Marketplace stay eager so the first
+// dashboard paint needs no extra round-trip. The secondary screens are
+// route-`lazy` so their heavy, route-local deps (recharts, html-to-image,
+// qrcode) land in async chunks instead of the entry bundle — see the bundle
+// budget in scripts/bundle-budget.json.
+function lazyScreen<M extends Record<string, unknown>>(
+  loader: () => Promise<M>,
+  pick: (m: M) => ComponentType,
+) {
+  return async () => ({ Component: pick(await loader()) });
+}
 
 function RootRedirect() {
   const { authenticated, state } = useAuth();
@@ -28,6 +35,20 @@ function RootRedirect() {
   return <WalletConnect />;
 }
 
+// Shown during the initial load of a lazy route (e.g. a deep link straight to
+// /dashboard/my-activity) so a direct hit renders the branded surface rather
+// than a blank frame while the chunk fetches. In-app navigation keeps the
+// current UI mounted during the lazy fetch, so this only covers cold deep links.
+function RouteFallback() {
+  return (
+    <div className="min-h-dvh bg-surface-page" aria-hidden="true">
+      <div className="flex min-h-dvh items-center justify-center">
+        <div className="skeleton-shimmer h-10 w-10 rounded-full" />
+      </div>
+    </div>
+  );
+}
+
 export const router = createBrowserRouter([
   {
     path: "/",
@@ -36,6 +57,7 @@ export const router = createBrowserRouter([
   {
     path: "/dashboard",
     Component: DashboardLayout,
+    HydrateFallback: RouteFallback,
     children: [
       {
         index: true,
@@ -43,24 +65,39 @@ export const router = createBrowserRouter([
       },
       {
         path: "my-activity",
-        Component: MyActivity,
+        lazy: lazyScreen(
+          () => import("@/app/components/MyActivity"),
+          (m) => m.MyActivity,
+        ),
       },
       {
         path: "transparency",
-        Component: Transparency,
+        lazy: lazyScreen(
+          () => import("@/app/components/Transparency"),
+          (m) => m.Transparency,
+        ),
       },
       {
         path: "rfq/:rfqId",
-        Component: RFQDetailWrapper,
+        lazy: lazyScreen(
+          () => import("@/app/components/RFQDetailWrapper"),
+          (m) => m.RFQDetailWrapper,
+        ),
       },
       // Flat, role-free taker cockpits (the /my-quotes subtree is deleted per #10).
       {
         path: "quote/:quoteId/reveal",
-        Component: RevealQuoteWrapper,
+        lazy: lazyScreen(
+          () => import("@/app/components/RevealQuoteWrapper"),
+          (m) => m.RevealQuoteWrapper,
+        ),
       },
       {
         path: "quote/:quoteId/settle",
-        Component: SettleQuoteWrapper,
+        lazy: lazyScreen(
+          () => import("@/app/components/SettleQuoteWrapper"),
+          (m) => m.SettleQuoteWrapper,
+        ),
       },
     ],
   },
@@ -69,7 +106,10 @@ export const router = createBrowserRouter([
     ? [
         {
           path: "/dev/stories",
-          Component: ComponentStories,
+          lazy: lazyScreen(
+            () => import("@/app/components/ComponentStories"),
+            (m) => m.ComponentStories,
+          ),
         },
       ]
     : []),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -71,6 +71,31 @@ export default defineConfig(({ mode, command }) => {
     },
     build: {
       outDir: "build",
+      rollupOptions: {
+        output: {
+          // Pin the heavy, rarely-changing vendor deps into stably-named chunks
+          // so they cache across app-code deploys (and so the bundle budget
+          // measures a meaningful boundary). web3.js + Anchor are needed at boot
+          // by the wallet providers, so vendor-solana loads eagerly; recharts is
+          // only reached from lazy routes, so vendor-charts stays async.
+          manualChunks(id) {
+            if (!id.includes("node_modules")) return undefined;
+            if (
+              id.includes("@solana") ||
+              id.includes("@coral-xyz") ||
+              id.includes("web3.js") ||
+              id.includes("jayson") ||
+              id.includes("rpc-websockets")
+            ) {
+              return "vendor-solana";
+            }
+            if (id.includes("recharts") || id.includes("/d3-") || id.includes("victory")) {
+              return "vendor-charts";
+            }
+            return undefined;
+          },
+        },
+      },
     },
     test: {
       // No env injection needed: src/chain/env.ts falls back to committed


### PR DESCRIPTION
## Problem

Everything shipped in a single eager entry chunk (~592 kB gzip) — no `manualChunks`, no `React.lazy`. `web3.js` + Anchor + recharts + html-to-image + qrcode all loaded on first paint, with almost no budget headroom.

## Fix

- **Route-lazy** the 5 secondary dashboard screens (`my-activity`, `transparency`, `rfq/:id`, `reveal`, `settle`) + the dev `/dev/stories` route via React Router `lazy`. The shell (`DashboardLayout`) and the index Marketplace stay eager for instant first paint; a `HydrateFallback` covers cold deep links.
- **Lazy** the marketplace `OpenInterestByToken` (recharts) via `React.lazy` + `Suspense` so recharts leaves the entry chunk.
- **`manualChunks`** pins `web3.js`/Anchor into `vendor-solana` (eager, but now stably-named → cached across app-code deploys) and recharts into `vendor-charts`.
- **Honest budget:** `check-bundle-size.mjs` now also measures **initial load = entry + `modulepreload` chunks** (what the browser actually fetches on first paint), not just the index shell. Re-baselined `bundle-budget.json`.

## Results (gzip)

| Metric | Before | After |
| --- | ---: | ---: |
| Entry shell (`index`) | 592 kB | **101.5 kB** |
| Initial load (first-paint JS) | ~592 kB | **552.9 kB** |
| Total JS | ~592 kB | 591.2 kB (unchanged — splitting defers, doesn't delete) |

`html-to-image`, `qrcode`, and the 5 route screens defer fully (not in the preload set). `vendor-charts` is still warmed because the landing renders a chart, but non-blocking (Suspense skeleton). Follow-up worth considering: defer `ProofInspector` (pulled eager via `SubmitQuoteModal`).

## Verification

- `npm run typecheck` clean · `npm test` 245/245 · `npm run lint` 6 warnings/0 errors (one new benign react-refresh from `RouteFallback`).
- `node scripts/check-bundle-size.mjs` passes with headroom (initial 552.9 < 580, total 591.2 < 615).
- Browser (dev): root boots clean; the lazy `/dev/stories` route resolves cold with recharts (`RewardsSection`) + `ProofInspector` rendering, zero console errors. The auth-gated marketplace chart uses the identical `React.lazy`+`Suspense`+recharts path (no dev wallet this session to drive it directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)