### PR TITLE
security: add a production Content-Security-Policy

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,6 +34,44 @@ const LG_DEFAULTS = {
   mainnet: "https://liquidity-guard-mainnet-162b828790cf.herokuapp.com",
 } as const;
 
+// Production Content-Security-Policy. Injected as a <meta> only on `vite build`
+// (never the dev server — a page CSP would break Vite's HMR websocket and
+// tooling). GitHub Pages can't set response headers, so the meta is the only
+// lever; frame-ancestors / report-uri (header-only directives) are therefore
+// out of scope. Rationale per directive:
+//   script-src 'self'          — only our own bundled chunks execute; wallet
+//                                extensions run as content scripts (their own
+//                                origin) and talk via postMessage, so they need
+//                                no page-CSP exception.
+//   style-src  'unsafe-inline' — motion/recharts/Tailwind set inline style
+//                                attributes; unavoidable and low-risk vs scripts.
+//   connect-src                — Solana RPC (https + wss for subscriptions),
+//                                the per-cluster liquidity-guard upstreams, and
+//                                the Jupiter token/price API (src/app/lib/jupiter.ts).
+//   img-src https:             — remote token logos (Jupiter CDN) + data: (QR /
+//                                html-to-image receipts).
+function buildCsp(): string {
+  return [
+    "default-src 'self'",
+    "base-uri 'self'",
+    "object-src 'none'",
+    "script-src 'self'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data: blob: https:",
+    "font-src 'self'",
+    "worker-src 'self' blob:",
+    "frame-src 'self'",
+    "form-action 'self'",
+    [
+      "connect-src 'self'",
+      "https://api.devnet.solana.com wss://api.devnet.solana.com",
+      "https://api.mainnet-beta.solana.com wss://api.mainnet-beta.solana.com",
+      `${LG_DEFAULTS.devnet} ${LG_DEFAULTS.mainnet}`,
+      "https://lite-api.jup.ag",
+    ].join(" "),
+  ].join("; ");
+}
+
 export default defineConfig(({ mode, command }) => {
   const env = loadEnv(mode, process.cwd(), "");
   const lgTarget = {
@@ -49,8 +87,21 @@ export default defineConfig(({ mode, command }) => {
     rewrite: (p) => p.replace(new RegExp(`^/liquidity-guard/${segment}`), ""),
   });
 
+  // Inject the production CSP <meta> at build time only (apply: "build").
+  const cspPlugin = {
+    name: "inject-csp",
+    apply: "build" as const,
+    transformIndexHtml: () => [
+      {
+        tag: "meta",
+        attrs: { "http-equiv": "Content-Security-Policy", content: buildCsp() },
+        injectTo: "head-prepend" as const,
+      },
+    ],
+  };
+
   return {
-    plugins: [react(), tailwindcss()],
+    plugins: [react(), tailwindcss(), cspPlugin],
     resolve: {
       alias: {
         // Support Figma Make asset imports in Vite


### PR DESCRIPTION
## Why

Wallet private keys live in the page context, so any future XSS is high-impact. A CSP shrinks that surface and also mitigates the cleartext reveal-ticket read (A9). GitHub Pages can't set response headers, so the policy ships as a `<meta http-equiv>`.

## How

- Injected via a Vite `transformIndexHtml` plugin with **`apply: "build"`** — the dev server (HMR websocket, injected tooling) is never constrained. Dev `index.html` stays CSP-free.
- Directives:
  - `script-src 'self'` — only our bundled chunks execute. Wallet extensions run as content scripts (their own origin, communicating via `postMessage`), so they need no page-CSP exception.
  - `style-src 'self' 'unsafe-inline'` — motion / recharts / Tailwind set inline `style` attributes (unavoidable; low-risk vs scripts).
  - `connect-src` — Solana RPC (https + `wss:` for account subscriptions), the two Heroku liquidity-guard upstreams, and the Jupiter token/price API (`src/app/lib/jupiter.ts`).
  - `img-src 'self' data: blob: https:` — remote token logos + QR / html-to-image receipts.
  - `object-src 'none'`, `base-uri 'self'`, `form-action 'self'`. (`frame-ancestors` / `report-uri` are header-only, out of scope for a meta CSP.)

## Verification (against the built bundle via `vite preview`)

- Connect screen renders under the CSP — `script-src 'self'` doesn't break the app; no `Refused to…` violations on boot (only unrelated wallet-extension warnings).
- `connect-src` probed from the page: `lite-api.jup.ag`, the Heroku LG `/health`, and `api.devnet.solana.com` all reach the network; a non-whitelisted control (`example.com`) is **blocked** — confirming the policy is enforcing.
- `npm run typecheck` clean · `npm run build` OK · dev/e2e unaffected (prod-only).

**Reviewer spot-check suggested:** on the Vercel preview (which serves this CSP build), confirm a real wallet connect + a post-auth chart/QR render, since the extension-popup path couldn't be driven headless this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)