### PR TITLE
fix(responsive): mobile bottom sheets, safe-area insets, +5 @mobile e2e cases

### DIFF
--- a/e2e/specs/responsive-mobile.e2e.spec.ts
+++ b/e2e/specs/responsive-mobile.e2e.spec.ts
@@ -4,12 +4,27 @@
 // the other read-only specs.
 import { test, expect } from "../fixtures";
 import { OPEN_RFQ_WITH_COMMIT_WINDOW } from "../fixtures/known-rfqs";
+import { openFirstRfqInGroup } from "../helpers/rfq";
 
 async function expectNoHorizontalOverflow(page: import("@playwright/test").Page) {
   const overflows = await page.evaluate(
     () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
   );
   expect(overflows).toBe(false);
+}
+
+// Assert a floating element sits fully inside the phone viewport (the hard-won
+// rule: an edge-anchored panel must never clip off a 390px screen).
+async function expectInViewport(
+  page: import("@playwright/test").Page,
+  locator: import("@playwright/test").Locator,
+) {
+  const box = await locator.boundingBox();
+  const viewport = page.viewportSize();
+  expect(box).not.toBeNull();
+  expect(viewport).not.toBeNull();
+  expect(box!.x).toBeGreaterThanOrEqual(0);
+  expect(box!.x + box!.width).toBeLessThanOrEqual(viewport!.width + 1);
 }
 
 test.describe("Mobile viewport @mobile", () => {
@@ -92,4 +107,75 @@ test.describe("Mobile viewport @mobile", () => {
     });
     await expectNoHorizontalOverflow(makerPage);
   });
+
+  test("notifications open as a bottom sheet from the navbar bell", async ({ makerPage }) => {
+    // The bell is always in the top bar; below md the inbox renders in a vaul
+    // drawer (GlassPopover is a ≥md-only primitive with no collision handling).
+    await makerPage.goto("/dashboard");
+    await makerPage.getByRole("button", { name: /^Notifications/ }).click();
+    const sheet = makerPage.getByRole("dialog");
+    await expect(sheet).toBeVisible();
+    await expectInViewport(makerPage, sheet);
+    await expectNoHorizontalOverflow(makerPage);
+    await makerPage.keyboard.press("Escape");
+  });
+
+  test("network switcher opens within the viewport from the mobile menu", async ({ makerPage }) => {
+    await makerPage.goto("/dashboard");
+    await makerPage.getByRole("button", { name: "Toggle menu" }).click();
+    await makerPage.getByRole("combobox", { name: "Select Solana network" }).click();
+    // Radix Select is portaled + collision-aware; assert the options are on-screen.
+    const listbox = makerPage.getByRole("listbox");
+    await expect(listbox).toBeVisible();
+    await expectInViewport(makerPage, listbox);
+    await makerPage.keyboard.press("Escape");
+    await expectNoHorizontalOverflow(makerPage);
+  });
+
+  test("share sheet (QR) opens as a bottom sheet on the RFQ detail", async ({ makerPage }) => {
+    await makerPage.goto(`/dashboard/rfq/${OPEN_RFQ_WITH_COMMIT_WINDOW}`);
+    await makerPage.getByRole("button", { name: "Share this RFQ" }).click();
+    const sheet = makerPage.getByRole("dialog");
+    await expect(sheet).toBeVisible();
+    await expect(sheet.getByRole("img")).toBeVisible();
+    await expectInViewport(makerPage, sheet);
+    await expectNoHorizontalOverflow(makerPage);
+    await makerPage.keyboard.press("Escape");
+  });
+
+  test("proof inspector opens as a bottom sheet (component gallery)", async ({ makerPage }) => {
+    // ProofInspector's "Inspect liquidity proof" trigger only renders on
+    // Revealed/Selected RFQ details, whose detail pages aren't in the read-only
+    // cassette. Exercise its ResponsiveModal bottom sheet via the DEV gallery,
+    // which needs neither chain data nor a specific wallet role.
+    await makerPage.goto("/dev/stories");
+    await makerPage.getByRole("button", { name: "Open proof inspector" }).click();
+    const sheet = makerPage.getByRole("dialog");
+    await expect(sheet).toBeVisible();
+    await expectInViewport(makerPage, sheet);
+    await makerPage.keyboard.press("Escape");
+  });
+
+  test("token selector opens as a bottom sheet inside the create wizard", async ({ makerPage }) => {
+    // TokenSelector migrated to ResponsiveModal (A6) → a vaul bottom sheet below
+    // md. It opens from within the create wizard (itself a bottom sheet), so
+    // this also exercises the nested-drawer case.
+    await makerPage.goto("/dashboard");
+    await makerPage.getByRole("button", { name: "Toggle menu" }).click();
+    await makerPage.getByRole("button", { name: "Create RFQ" }).last().click();
+    const wizard = makerPage.getByRole("dialog");
+    await wizard.getByRole("button", { name: "Select base token" }).click();
+    const sheet = makerPage.getByRole("dialog").filter({ hasText: "Listed Tokens" });
+    await expect(sheet).toBeVisible();
+    await expect(sheet.getByPlaceholder(/Search by name/)).toBeVisible();
+    await expectInViewport(makerPage, sheet);
+    await expectNoHorizontalOverflow(makerPage);
+    await makerPage.keyboard.press("Escape");
+  });
+
+  // NOTE: the RFQActionBar confirm dialog (A6-migrated to ResponsiveModal) is
+  // not covered here — its actions (open/cancel/select/set-facilitator) are
+  // legal only for the RFQ maker or a quote owner, and the hermetic wallets are
+  // ephemeral + uninvolved. Its mobile bottom-sheet behaviour is the same
+  // ResponsiveModal exercised by the commit-modal and token-selector cases.
 });

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>UnleakTrade — App</title>
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon.png" />
   </head>

--- a/src/app/components/MainNavbar.tsx
+++ b/src/app/components/MainNavbar.tsx
@@ -187,7 +187,7 @@ export function MainNavbar({ currentView, onNavigate, onCreateRFQ }: MainNavbarP
           />
 
           <div className="fixed top-(--nav-h) right-0 bottom-0 w-full max-w-sm bg-surface-page/98 backdrop-blur-xl border-l border-white/10 z-40 lg:hidden overflow-y-auto motion-safe:animate-in motion-safe:slide-in-from-right motion-safe:duration-300">
-            <div className="p-6 space-y-4">
+            <div className="px-6 pt-6 pb-[calc(1.5rem+env(safe-area-inset-bottom))] space-y-4">
               <div>
                 <Button
                   onClick={handleCreateRFQ}

--- a/src/app/components/RFQActionBar.tsx
+++ b/src/app/components/RFQActionBar.tsx
@@ -38,14 +38,7 @@ import { findQuoteByPda } from "@/app/lib/quote-lookup";
 import { resolveTokenMeta } from "@/app/lib/tokens";
 import type { FacilitatorUpdate } from "@/types/rfq";
 import { Button } from "@/app/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/app/components/ui/dialog";
+import { ResponsiveModal } from "@/app/components/ResponsiveModal";
 import { Input } from "@/app/components/ui/input";
 import { Label } from "@/app/components/ui/label";
 import { RFQActionSheet } from "@/app/components/RFQActionSheet";
@@ -337,16 +330,14 @@ export function RFQActionBar({
         <p className="text-right text-sm text-white/40">{emptyStateMessage}</p>
       )}
 
-      <Dialog
+      <ResponsiveModal
         open={confirm !== null && confirm !== "edit"}
         onOpenChange={(open) => !open && setConfirm(null)}
+        title={pending?.label ?? "Confirm"}
+        description={pending?.description}
+        contentClassName="bg-surface-page"
       >
-        <DialogContent className="border-white/10 bg-surface-page text-white">
-          <DialogHeader>
-            <DialogTitle>{pending?.label ?? "Confirm"}</DialogTitle>
-            <DialogDescription className="text-white/60">{pending?.description}</DialogDescription>
-          </DialogHeader>
-
+        <div className="space-y-4">
           {confirm === "open" && (
             <BondBreakdown
               bondAmount={rfq.bondAmount}
@@ -381,7 +372,7 @@ export function RFQActionBar({
             </div>
           )}
 
-          <DialogFooter>
+          <div className="flex flex-col-reverse gap-2 pt-2 sm:flex-row sm:justify-end">
             <Button
               variant="ghost"
               onClick={() => setConfirm(null)}
@@ -398,9 +389,9 @@ export function RFQActionBar({
               {busy && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
               {pending?.label ?? "Confirm"}
             </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+          </div>
+        </div>
+      </ResponsiveModal>
     </>
   );
 }

--- a/src/app/components/RFQActionSheet.tsx
+++ b/src/app/components/RFQActionSheet.tsx
@@ -32,7 +32,7 @@ export function RFQActionSheet({ children, title = "Actions", className }: RFQAc
       {/* Bottom action bar + sheet on mobile */}
       <div className="md:hidden">
         <Drawer>
-          <div className="fixed inset-x-0 bottom-0 z-40 border-t border-white/10 bg-surface-page/90 p-3 backdrop-blur-xl">
+          <div className="fixed inset-x-0 bottom-0 z-40 border-t border-white/10 bg-surface-page/90 px-3 pt-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))] backdrop-blur-xl">
             <DrawerTrigger asChild>
               <Button className="w-full bg-gradient-to-r from-cyan-500 to-blue-500 text-white hover:from-cyan-600 hover:to-blue-600">
                 <ChevronUp className="mr-2 h-4 w-4" />

--- a/src/app/components/TokenSelector.tsx
+++ b/src/app/components/TokenSelector.tsx
@@ -1,13 +1,7 @@
 import { useState } from "react";
 import { Button } from "@/app/components/ui/button";
 import { Input } from "@/app/components/ui/input";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-} from "@/app/components/ui/dialog";
+import { ResponsiveModal } from "@/app/components/ResponsiveModal";
 import { Search, ChevronDown, Plus } from "lucide-react";
 import { motion, AnimatePresence } from "motion/react";
 import { Label } from "@/app/components/ui/label";
@@ -108,160 +102,156 @@ export function TokenSelector({ value, onChange, label, excludeToken }: TokenSel
         <ChevronDown className="h-4 w-4 text-white/50" />
       </Button>
 
-      <Dialog open={isOpen} onOpenChange={setIsOpen}>
-        <DialogContent className="bg-surface-raised border-white/10 text-white max-w-md">
-          <DialogHeader>
-            <DialogTitle>{label}</DialogTitle>
-            <DialogDescription>
-              Select from listed SPL tokens or enter an unlisted token address
-            </DialogDescription>
-          </DialogHeader>
+      <ResponsiveModal
+        open={isOpen}
+        onOpenChange={setIsOpen}
+        title={label}
+        description="Select from listed SPL tokens or enter an unlisted token address"
+        contentClassName="max-w-md"
+      >
+        <Tabs
+          value={mode}
+          onValueChange={(v) => setMode(v as "listed" | "unlisted")}
+          className="w-full"
+        >
+          <TabsList className="grid w-full grid-cols-2 bg-white/5">
+            <TabsTrigger
+              value="listed"
+              className="data-[state=active]:bg-purple-500/20 data-[state=active]:text-purple-300"
+            >
+              Listed Tokens
+            </TabsTrigger>
+            <TabsTrigger
+              value="unlisted"
+              className="data-[state=active]:bg-cyan-500/20 data-[state=active]:text-cyan-300"
+            >
+              <Plus className="h-4 w-4 mr-1" />
+              Unlisted
+            </TabsTrigger>
+          </TabsList>
 
-          <Tabs
-            value={mode}
-            onValueChange={(v) => setMode(v as "listed" | "unlisted")}
-            className="w-full"
-          >
-            <TabsList className="grid w-full grid-cols-2 bg-white/5">
-              <TabsTrigger
-                value="listed"
-                className="data-[state=active]:bg-purple-500/20 data-[state=active]:text-purple-300"
-              >
-                Listed Tokens
-              </TabsTrigger>
-              <TabsTrigger
-                value="unlisted"
-                className="data-[state=active]:bg-cyan-500/20 data-[state=active]:text-cyan-300"
-              >
-                <Plus className="h-4 w-4 mr-1" />
-                Unlisted
-              </TabsTrigger>
-            </TabsList>
+          <TabsContent value="listed" className="space-y-4 mt-4">
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-white/40" />
+              <Input
+                placeholder="Search by name, symbol, or mint address..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="pl-10 bg-white/5 border-white/10 text-white placeholder:text-white/30"
+              />
+            </div>
 
-            <TabsContent value="listed" className="space-y-4 mt-4">
-              <div className="relative">
-                <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-white/40" />
+            <div className="max-h-[400px] overflow-y-auto space-y-1">
+              <AnimatePresence>
+                {filteredTokens.map((token, index) => (
+                  <motion.button
+                    key={token.mint}
+                    initial={{ opacity: 0, y: -10 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0, y: 10 }}
+                    transition={{ delay: index * 0.02 }}
+                    onClick={() => handleSelectListed(token)}
+                    className="w-full flex items-center gap-3 p-3 rounded-lg hover:bg-white/5 transition-colors text-left"
+                  >
+                    <div className="w-10 h-10 rounded-full bg-gradient-to-br from-purple-500/20 to-blue-500/20 flex items-center justify-center border border-white/10 shrink-0">
+                      <span className="font-bold">{token.symbol[0]}</span>
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <div className="font-semibold">{token.symbol}</div>
+                      <div className="text-sm text-white/50 truncate">{token.name}</div>
+                    </div>
+                    <div className="text-xs text-white/30 font-mono">
+                      {token.mint.slice(0, 4)}...{token.mint.slice(-4)}
+                    </div>
+                  </motion.button>
+                ))}
+              </AnimatePresence>
+
+              {filteredTokens.length === 0 && (
+                <div className="text-center py-8 text-white/40">
+                  <p>No tokens found</p>
+                  <p className="text-sm mt-2">Try a different search query</p>
+                </div>
+              )}
+            </div>
+          </TabsContent>
+
+          <TabsContent value="unlisted" className="space-y-4 mt-4">
+            <div className="p-4 rounded-lg bg-cyan-500/5 border border-cyan-500/20">
+              <p className="text-sm text-white/70">
+                <span className="font-semibold text-cyan-300">Trade any SPL token:</span> Enter the
+                mint address of any unlisted token to create an OTC deal with ZK-verified liquidity.
+              </p>
+            </div>
+
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="customMint" className="text-white/90">
+                  Token Mint Address <span className="text-red-400">*</span>
+                </Label>
                 <Input
-                  placeholder="Search by name, symbol, or mint address..."
-                  value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
-                  className="pl-10 bg-white/5 border-white/10 text-white placeholder:text-white/30"
+                  id="customMint"
+                  placeholder="Enter SPL token mint address..."
+                  value={customMint}
+                  onChange={(e) => setCustomMint(e.target.value)}
+                  className="bg-white/5 border-white/10 text-white placeholder:text-white/30 font-mono text-sm"
                 />
               </div>
 
-              <div className="max-h-[400px] overflow-y-auto space-y-1">
-                <AnimatePresence>
-                  {filteredTokens.map((token, index) => (
-                    <motion.button
-                      key={token.mint}
-                      initial={{ opacity: 0, y: -10 }}
-                      animate={{ opacity: 1, y: 0 }}
-                      exit={{ opacity: 0, y: 10 }}
-                      transition={{ delay: index * 0.02 }}
-                      onClick={() => handleSelectListed(token)}
-                      className="w-full flex items-center gap-3 p-3 rounded-lg hover:bg-white/5 transition-colors text-left"
-                    >
-                      <div className="w-10 h-10 rounded-full bg-gradient-to-br from-purple-500/20 to-blue-500/20 flex items-center justify-center border border-white/10 shrink-0">
-                        <span className="font-bold">{token.symbol[0]}</span>
-                      </div>
-                      <div className="flex-1 min-w-0">
-                        <div className="font-semibold">{token.symbol}</div>
-                        <div className="text-sm text-white/50 truncate">{token.name}</div>
-                      </div>
-                      <div className="text-xs text-white/30 font-mono">
-                        {token.mint.slice(0, 4)}...{token.mint.slice(-4)}
-                      </div>
-                    </motion.button>
-                  ))}
-                </AnimatePresence>
-
-                {filteredTokens.length === 0 && (
-                  <div className="text-center py-8 text-white/40">
-                    <p>No tokens found</p>
-                    <p className="text-sm mt-2">Try a different search query</p>
-                  </div>
-                )}
-              </div>
-            </TabsContent>
-
-            <TabsContent value="unlisted" className="space-y-4 mt-4">
-              <div className="p-4 rounded-lg bg-cyan-500/5 border border-cyan-500/20">
-                <p className="text-sm text-white/70">
-                  <span className="font-semibold text-cyan-300">Trade any SPL token:</span> Enter
-                  the mint address of any unlisted token to create an OTC deal with ZK-verified
-                  liquidity.
-                </p>
-              </div>
-
-              <div className="space-y-4">
+              <div className="grid grid-cols-2 gap-4">
                 <div className="space-y-2">
-                  <Label htmlFor="customMint" className="text-white/90">
-                    Token Mint Address <span className="text-red-400">*</span>
+                  <Label htmlFor="customSymbol" className="text-white/90">
+                    Symbol <span className="text-red-400">*</span>
                   </Label>
                   <Input
-                    id="customMint"
-                    placeholder="Enter SPL token mint address..."
-                    value={customMint}
-                    onChange={(e) => setCustomMint(e.target.value)}
-                    className="bg-white/5 border-white/10 text-white placeholder:text-white/30 font-mono text-sm"
+                    id="customSymbol"
+                    placeholder="e.g. TOKEN"
+                    value={customSymbol}
+                    onChange={(e) => setCustomSymbol(e.target.value)}
+                    className="bg-white/5 border-white/10 text-white placeholder:text-white/30 uppercase"
                   />
                 </div>
 
-                <div className="grid grid-cols-2 gap-4">
-                  <div className="space-y-2">
-                    <Label htmlFor="customSymbol" className="text-white/90">
-                      Symbol <span className="text-red-400">*</span>
-                    </Label>
-                    <Input
-                      id="customSymbol"
-                      placeholder="e.g. TOKEN"
-                      value={customSymbol}
-                      onChange={(e) => setCustomSymbol(e.target.value)}
-                      className="bg-white/5 border-white/10 text-white placeholder:text-white/30 uppercase"
-                    />
-                  </div>
-
-                  <div className="space-y-2">
-                    <Label htmlFor="customDecimals" className="text-white/90">
-                      Decimals <span className="text-red-400">*</span>
-                    </Label>
-                    <Input
-                      id="customDecimals"
-                      type="number"
-                      placeholder="9"
-                      value={customDecimals}
-                      onChange={(e) => setCustomDecimals(e.target.value)}
-                      className="bg-white/5 border-white/10 text-white placeholder:text-white/30"
-                    />
-                  </div>
-                </div>
-
                 <div className="space-y-2">
-                  <Label htmlFor="customName" className="text-white/90">
-                    Token Name (Optional)
+                  <Label htmlFor="customDecimals" className="text-white/90">
+                    Decimals <span className="text-red-400">*</span>
                   </Label>
                   <Input
-                    id="customName"
-                    placeholder="e.g. My Custom Token"
-                    value={customName}
-                    onChange={(e) => setCustomName(e.target.value)}
+                    id="customDecimals"
+                    type="number"
+                    placeholder="9"
+                    value={customDecimals}
+                    onChange={(e) => setCustomDecimals(e.target.value)}
                     className="bg-white/5 border-white/10 text-white placeholder:text-white/30"
                   />
                 </div>
-
-                <Button
-                  onClick={handleAddCustomToken}
-                  disabled={!customMint || !customSymbol || !customDecimals}
-                  className="w-full bg-gradient-to-r from-cyan-500 via-cyan-600 to-cyan-700 hover:from-cyan-600 hover:via-cyan-700 hover:to-cyan-800 text-white disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  <Plus className="h-4 w-4 mr-2" />
-                  Add Unlisted Token
-                </Button>
               </div>
-            </TabsContent>
-          </Tabs>
-        </DialogContent>
-      </Dialog>
+
+              <div className="space-y-2">
+                <Label htmlFor="customName" className="text-white/90">
+                  Token Name (Optional)
+                </Label>
+                <Input
+                  id="customName"
+                  placeholder="e.g. My Custom Token"
+                  value={customName}
+                  onChange={(e) => setCustomName(e.target.value)}
+                  className="bg-white/5 border-white/10 text-white placeholder:text-white/30"
+                />
+              </div>
+
+              <Button
+                onClick={handleAddCustomToken}
+                disabled={!customMint || !customSymbol || !customDecimals}
+                className="w-full bg-gradient-to-r from-cyan-500 via-cyan-600 to-cyan-700 hover:from-cyan-600 hover:via-cyan-700 hover:to-cyan-800 text-white disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                <Plus className="h-4 w-4 mr-2" />
+                Add Unlisted Token
+              </Button>
+            </div>
+          </TabsContent>
+        </Tabs>
+      </ResponsiveModal>
     </>
   );
 }

--- a/src/app/components/ui/drawer.tsx
+++ b/src/app/components/ui/drawer.tsx
@@ -45,7 +45,10 @@ function DrawerContent({
       <DrawerPrimitive.Content
         data-slot="drawer-content"
         className={cn(
-          "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-2xl border border-white/10 bg-surface-raised text-white",
+          // pb-[safe-area] keeps the last control clear of the iOS home
+          // indicator on every vaul bottom sheet (ResponsiveModal, action
+          // sheet, notifications, guard status) at once.
+          "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-2xl border border-white/10 bg-surface-raised pb-[env(safe-area-inset-bottom)] text-white",
           className,
         )}
         {...props}


### PR DESCRIPTION
Bundles the P2 responsiveness cluster (A5 + A6 + A7).

## A6 — two form overlays bypassed the ResponsiveModal split
`TokenSelector` and the `RFQActionBar` confirm both used a raw centred Radix `Dialog`, so on mobile they rendered as centred dialogs instead of the vaul bottom sheet every other form modal uses. Both now route through `ResponsiveModal` (Dialog ≥768px / drawer below). TokenSelector opens from within the create wizard (itself a bottom sheet), so this nests a drawer inside a drawer — **verified working** by the new mobile spec.

## A7 — iOS safe-area insets
`viewport-fit=cover` + `env(safe-area-inset-bottom)` padding on the shared vaul `DrawerContent` (covers every bottom sheet at once), the RFQ action sheet's fixed bar, and the mobile menu, so the last control clears the home indicator.

## A5 — missing @mobile e2e coverage
New `@mobile` cases (content visible · bounding box inside the 390px viewport · no horizontal overflow) for: **notification drawer**, **network switcher** (Radix Select), **share/QR sheet**, **proof inspector** (via the DEV gallery — its inspect trigger only renders on Revealed/Selected details, which aren't in the read-only cassette), and the **token-selector bottom sheet** inside the create wizard. The action-bar confirm isn't directly covered (its actions are legal only for a maker/quote-owner, and hermetic wallets are ephemeral + uninvolved) — same ResponsiveModal, covered transitively.

## Verification
- `npm run typecheck` clean · `npm test` 245/245.
- **Mobile e2e: 13/13 pass** (8 existing + 5 new). Desktop modal flows (SubmitQuoteModal) 4/4 — the ≥md Dialog path of the migrated overlays is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)