### PR TITLE
ci(deploy): re-enable workflow_dispatch for transient Pages flakes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,11 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [main]
-  # workflow_dispatch:
+  # Manual re-run: GitHub Pages' deploy-pages step occasionally fails with a
+  # transient "Deployment failed, try again later." Re-running the workflow
+  # (Actions → Deploy → Run workflow) rebuilds + redeploys without an empty
+  # commit. concurrency.cancel-in-progress keeps only the latest run.
+  workflow_dispatch:
 permissions:
   contents: read
   pages: write


### PR DESCRIPTION
## Why

`deploy.yml` had `workflow_dispatch` commented out, so when the GitHub Pages `deploy-pages` step hits its known transient `Deployment failed, try again later.` error (build + artifact upload succeed; only the final deploy fails), the only way to re-deploy was pushing an empty commit.

## Fix

Re-enable `workflow_dispatch` so the deploy can be re-run from the Actions UI. `concurrency.cancel-in-progress` already ensures only the latest run wins.

(An auto-retry can't cleanly wrap the `actions/deploy-pages@v5` composite step — retry actions wrap `run:` commands — so manual re-run is the pragmatic mechanism; the flake self-heals on the next push regardless.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)