### PR TITLE
docs(chain): correct list-freshness comments + note full-scan trackers

### DIFF
--- a/src/chain/accounts/byKeys.ts
+++ b/src/chain/accounts/byKeys.ts
@@ -2,8 +2,9 @@
 // quote keys referenced by a set of Settled RFQs, fetch them all in one
 // `fetchMultiple` round-trip and hand back a base58-keyed Map. Settled
 // accounts are immutable, so — unlike useDecodedAccount — there is no
-// websocket subscription here; freshness follows the same TanStack defaults
-// the list hooks use (refetch-on-focus + the shared write-path invalidation).
+// websocket subscription here, and no refresh is needed beyond the shared
+// write-path invalidation + staleTime the list hooks use (refetchOnWindowFocus
+// is off globally — see QueryProvider).
 
 import type { PublicKey } from "@solana/web3.js";
 import { useQuery, type UseQueryResult } from "@tanstack/react-query";

--- a/src/chain/accounts/lists.ts
+++ b/src/chain/accounts/lists.ts
@@ -62,9 +62,12 @@ function memcmp(offset: number, key: PublicKey): MemcmpFilter {
 /**
  * Shared getProgramAccounts plumbing for list reads. Unlike useDecodedAccount,
  * lists do NOT open a websocket subscription (those stay detail-page-only — no
- * polling loops); freshness comes from TanStack's refetch-on-focus. Query keys
- * follow the [account, programId, "all", …] convention; react-query hashes them
- * structurally, so building the array inline each render is fine.
+ * polling loops). Freshness comes from the shared write-path invalidation (after
+ * a tx) plus the 10s staleTime on remount — refetchOnWindowFocus is off globally
+ * (QueryProvider) so we don't re-run the heavy, throttle-prone getProgramAccounts
+ * on every tab focus. Query keys follow the [account, programId, "all", …]
+ * convention; react-query hashes them structurally, so building the array inline
+ * each render is fine.
  */
 function useProgramAccounts<TRaw, T>(
   accountKey: string,
@@ -133,7 +136,11 @@ export function useQuoteAccountsByTaker(
   );
 }
 
-/** Every slashed-bond tracker — the read-only transparency ledger. */
+/**
+ * Every slashed-bond tracker — the read-only transparency ledger. Full
+ * unfiltered getProgramAccounts scan (no memcmp): fine at current fixture scale,
+ * but add a filter / pagination if the tracker set grows large on mainnet.
+ */
 export function useSlashedBondsTrackerAccounts(): UseQueryResult<
   ProgramAccount<SlashedBondsTrackerAccount>[]
 > {
@@ -146,7 +153,10 @@ export function useSlashedBondsTrackerAccounts(): UseQueryResult<
   );
 }
 
-/** Every protocol-fee tracker — per-mint fee totals for the transparency page. */
+/**
+ * Every protocol-fee tracker — per-mint fee totals for the transparency page.
+ * Full unfiltered getProgramAccounts scan (see the slashed-bonds note above).
+ */
 export function useFeesTrackerAccounts(): UseQueryResult<ProgramAccount<FeesTrackerAccount>[]> {
   return useProgramAccounts(
     "feesTracker",


### PR DESCRIPTION
Reconciles A8 (freshness intent mismatch) + A14 (full-scan note) — comment-only.

## A8
`useProgramAccounts` and `byKeys` comments claimed freshness "comes from TanStack's refetch-on-focus", but `refetchOnWindowFocus` is **off globally** (`QueryProvider`) — deliberately, so the heavy, throttle-prone `getProgramAccounts` isn't re-run on every tab focus. Lists actually refresh via the shared write-path invalidation (after a tx) + the 10s `staleTime` on remount. Corrected both comments to match reality (kept the config as-is — enabling focus-refetch on the public devnet endpoint is exactly the throttling risk CLAUDE.md warns against).

## A14
Noted that `useSlashedBondsTrackerAccounts` / `useFeesTrackerAccounts` are unfiltered full `getProgramAccounts` scans (no `memcmp`) — fine at fixture scale, revisit with a filter/pagination if the tracker set grows on mainnet.

No behaviour change. `npm run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)