### PR TITLE
security: clear the reveal ticket after a successful reveal

### DIFF
--- a/src/app/components/RevealQuote.tsx
+++ b/src/app/components/RevealQuote.tsx
@@ -22,7 +22,13 @@ import { deriveSalt } from "@/chain/liquidityGuard";
 import { buildRevealQuoteTx } from "@/chain/instructions/taker";
 import { submitRfqTx } from "@/chain/instructions/shared";
 import { resolveTokenMeta } from "@/app/lib/tokens";
-import { hexToBytes, bytesToHex, loadTicket, parseTicket } from "@/app/lib/reveal-ticket";
+import {
+  hexToBytes,
+  bytesToHex,
+  loadTicket,
+  parseTicket,
+  clearTicket,
+} from "@/app/lib/reveal-ticket";
 import { ProofInspector } from "@/app/components/ProofInspector";
 import { PageShell } from "@/app/components/PageShell";
 import { TokenAmountInput } from "@/app/components/TokenAmountInput";
@@ -165,6 +171,9 @@ export function RevealQuote({ quote, rfqPda, rfq, onDone, onBack }: RevealQuoteP
         pendingMessage: "Revealing quote…",
         successMessage: "Quote revealed",
       });
+      // The bid is now on-chain; drop the cleartext ticket so the sealed amount
+      // + salt don't linger in localStorage past the confidential window.
+      clearTicket(rfqPda.toBase58());
       onDone();
     } catch {
       // toast already surfaced

--- a/src/app/lib/reveal-ticket.ts
+++ b/src/app/lib/reveal-ticket.ts
@@ -64,6 +64,21 @@ export function loadTicket(rfq: string): RevealTicket | null {
   }
 }
 
+/**
+ * Drop the saved ticket once the quote is revealed. The sealed amount + salt
+ * only need to persist through the commit→reveal window; once the amount is
+ * on-chain there's nothing left to recover, so clearing it shrinks the
+ * same-origin read surface for the confidential bid (see the file header).
+ * Best-effort — never throws.
+ */
+export function clearTicket(rfq: string): void {
+  try {
+    localStorage.removeItem(storageKey(rfq));
+  } catch {
+    // storage disabled — nothing to clear.
+  }
+}
+
 /** Validate + normalise an unknown object into a RevealTicket. Throws on a bad
  * shape so the "import ticket" path can surface a clear error. */
 export function parseTicket(input: unknown): RevealTicket {


### PR DESCRIPTION
## Why

The reveal ticket (`src/app/lib/reveal-ticket.ts`) persists the **sealed bid amount + salt in cleartext localStorage**, so a same-origin script could read a taker's confidential bid during the commit→reveal window. It only needs to survive that window (losing the salt = can't reveal).

## Fix

Add `clearTicket(rfq)` and call it in `RevealQuote` right after the reveal tx confirms. Once the amount is on-chain there's nothing left to recover, so removing the ticket shrinks the read surface for the confidential bid. The localStorage backup + downloadable-ticket recovery paths are untouched (they still cover the pre-reveal window). Paired with the production CSP (#51), which is the primary XSS mitigation.

## Verification

`npm run typecheck` clean · `npm test` 245/245. (The reveal flow needs a taker with a committed quote, not drivable in hermetic e2e; the change is a plain `localStorage.removeItem` gated on a confirmed on-chain success.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)