### PR TITLE
fix(a11y): enlarge sub-44px tap targets

### DIFF
--- a/src/app/components/AddressDisplay.tsx
+++ b/src/app/components/AddressDisplay.tsx
@@ -45,7 +45,7 @@ export function AddressDisplay({ address, visible = 4, className }: AddressDispl
         type="button"
         onClick={copy}
         aria-label="Copy address"
-        className="text-white/40 transition-colors hover:text-white/80"
+        className="-m-1.5 rounded p-1.5 text-white/40 transition-colors hover:text-white/80"
       >
         {copied ? (
           <Check className="h-3.5 w-3.5 text-state-settled" />
@@ -59,7 +59,7 @@ export function AddressDisplay({ address, visible = 4, className }: AddressDispl
           target="_blank"
           rel="noopener noreferrer"
           aria-label="View on Solscan"
-          className="text-white/40 transition-colors hover:text-white/80"
+          className="-m-1.5 rounded p-1.5 text-white/40 transition-colors hover:text-white/80"
         >
           <ExternalLink className="h-3.5 w-3.5" />
         </a>

--- a/src/app/components/MainNavbar.tsx
+++ b/src/app/components/MainNavbar.tsx
@@ -144,7 +144,7 @@ export function MainNavbar({ currentView, onNavigate, onCreateRFQ }: MainNavbarP
 
               <button
                 onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-                className="lg:hidden p-2.5 rounded-lg bg-white/5 border border-white/10 hover:bg-white/10 transition-all"
+                className="lg:hidden p-3 rounded-lg bg-white/5 border border-white/10 hover:bg-white/10 transition-all"
                 aria-label="Toggle menu"
               >
                 <AnimatePresence mode="wait">

--- a/src/app/components/NotificationCenter.tsx
+++ b/src/app/components/NotificationCenter.tsx
@@ -33,7 +33,7 @@ export function NotificationCenter() {
       size="sm"
       aria-label={unread > 0 ? `Notifications (${unread} unread)` : "Notifications"}
       onClick={() => setOpen((o) => !o)}
-      className="relative h-9 w-9 rounded-xl border border-white/10 bg-white/5 p-0 text-white/60 backdrop-blur-md hover:bg-white/10 hover:text-white"
+      className="relative h-11 w-11 rounded-xl border border-white/10 bg-white/5 p-0 text-white/60 backdrop-blur-md hover:bg-white/10 hover:text-white"
     >
       <Bell className="h-4 w-4" />
       {unread > 0 && (

--- a/src/app/components/marketplace/OpenInterestByToken.tsx
+++ b/src/app/components/marketplace/OpenInterestByToken.tsx
@@ -43,7 +43,7 @@ export function OpenInterestByToken({ buckets }: OpenInterestByTokenProps) {
                 onClick={() => setChartType("donut")}
                 aria-label="Donut chart view"
                 aria-pressed={chartType === "donut"}
-                className={`p-1.5 rounded transition-all ${
+                className={`p-2 rounded transition-all ${
                   chartType === "donut"
                     ? "bg-cyan-500/20 text-cyan-400"
                     : "text-white/40 hover:text-white/60"
@@ -55,7 +55,7 @@ export function OpenInterestByToken({ buckets }: OpenInterestByTokenProps) {
                 onClick={() => setChartType("bar")}
                 aria-label="Bar chart view"
                 aria-pressed={chartType === "bar"}
-                className={`p-1.5 rounded transition-all ${
+                className={`p-2 rounded transition-all ${
                   chartType === "bar"
                     ? "bg-cyan-500/20 text-cyan-400"
                     : "text-white/40 hover:text-white/60"


### PR DESCRIPTION
Addresses A11 (tap targets). A13/A14 handled separately — see below.

## Changes
- **Notification bell** 36→44px, **hamburger** 40→44px — the two pure-icon buttons in the mobile top bar, now comfortable touch targets (Apple HIG 44pt / Material 48dp).
- **AddressDisplay** copy + Solscan icons: 14px → **26px** hit area (padding + equal negative margin, so inline layout is unchanged). Verified 26×26px via `/dev/stories`.
- **OpenInterestByToken** chart-type toggles: 26→30px.

## Not included
- **A13 (fluid donut)** deliberately skipped: the fixed 160px `PieChart` already fits a 390px screen (not a bug), and swapping to `ResponsiveContainer` risks the absolutely-positioned center overlay — which can't be visually verified without a wallet to reach the marketplace. Left for a designer-in-the-loop pass.
- **A14 (tracker full-scan note)** shipped in #54.
- HealthPill chip (36px) left as-is — it's a text pill, AA-compliant, and bumping it would distort the navbar's visual rhythm.

## Verification
`npm run typecheck` clean · `npm test` 245/245 · AddressDisplay hit area measured at 26×26px in the component gallery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)