### PR TITLE
ci(bundle): gate on initial-load + total, make entry chunk informational

### DIFF
--- a/scripts/bundle-budget.json
+++ b/scripts/bundle-budget.json
@@ -1,6 +1,5 @@
 {
-  "comment": "Gzip budgets for build/assets JS, enforced by check-bundle-size.mjs in CI. Baseline 2026-07-05 (post code-split): entry shell 101.5 kB, initial load (entry + modulepreloads = first-paint JS) 552.9 kB, total 591.2 kB. web3.js + Anchor (vendor-solana, eager) and recharts (vendor-charts, warmed for the landing chart) dominate initial load; the 5 route-lazy screens + html-to-image/qrcode defer. Budgets are baseline + headroom — raise deliberately in a PR when a dependency legitimately grows the bundle.",
-  "entryGzipKb": 130,
+  "comment": "Gzip budgets for build/assets JS, enforced by check-bundle-size.mjs in CI. Baseline 2026-07-05 (vite 8.1.3): initial load (entry + modulepreloads = first-paint JS) 544.6 kB, total 582.4 kB. The entry chunk ALONE is reported but NOT gated: rolldown redistributes modules between the entry chunk and the first shared chunk across vite patch versions (8.0.8 split it at ~101 kB, 8.1.3 at ~193 kB) with no change to what the browser actually fetches — so entry-alone is non-portable. Initial load is the portable first-paint gate. Budgets are baseline + headroom — raise deliberately in a PR when a dependency legitimately grows the bundle.",
   "initialLoadGzipKb": 580,
   "totalJsGzipKb": 615
 }

--- a/scripts/check-bundle-size.mjs
+++ b/scripts/check-bundle-size.mjs
@@ -84,7 +84,11 @@ const fontsRawKb = Math.round(fonts.reduce((a, f) => a + rawKb(join(assetsDir, f
 
 const breaches = [];
 if (entryName === null) breaches.push("Could not identify the entry chunk from build/index.html");
-if (entryGzipKb > budget.entryGzipKb) {
+// The entry chunk alone is informational by default: rolldown shifts modules
+// between the entry chunk and the first shared chunk across vite patch versions
+// without changing what the browser fetches on first paint. Only gate it if a
+// budget is explicitly set. The portable gates are initialLoad + total below.
+if (budget.entryGzipKb != null && entryGzipKb > budget.entryGzipKb) {
   breaches.push(`Entry chunk ${entryGzipKb} kB gzip exceeds budget ${budget.entryGzipKb} kB`);
 }
 if (budget.initialLoadGzipKb != null && initialLoadGzipKb > budget.initialLoadGzipKb) {
@@ -105,7 +109,10 @@ const summary = {
   fontsRawKb,
   budget,
   headroom: {
-    entryKb: Math.round((budget.entryGzipKb - entryGzipKb) * 10) / 10,
+    entryKb:
+      budget.entryGzipKb != null
+        ? Math.round((budget.entryGzipKb - entryGzipKb) * 10) / 10
+        : null,
     initialLoadKb:
       budget.initialLoadGzipKb != null
         ? Math.round((budget.initialLoadGzipKb - initialLoadGzipKb) * 10) / 10
@@ -123,7 +130,9 @@ if (asJson) {
   console.log("| Metric | Size (gzip) | Budget | Headroom |");
   console.log("| --- | ---: | ---: | ---: |");
   console.log(
-    `| Entry chunk | ${entryGzipKb} kB | ${budget.entryGzipKb} kB | ${summary.headroom.entryKb} kB |`,
+    budget.entryGzipKb != null
+      ? `| Entry chunk | ${entryGzipKb} kB | ${budget.entryGzipKb} kB | ${summary.headroom.entryKb} kB |`
+      : `| Entry chunk (info) | ${entryGzipKb} kB | — | — |`,
   );
   if (budget.initialLoadGzipKb != null) {
     console.log(
@@ -140,7 +149,11 @@ if (asJson) {
     console.log(`⚠️ **Budget exceeded:** ${breaches.join("; ")}`);
   }
 } else {
-  console.log(`Entry chunk (${entryName}): ${entryGzipKb} kB gzip (budget ${budget.entryGzipKb})`);
+  console.log(
+    budget.entryGzipKb != null
+      ? `Entry chunk (${entryName}): ${entryGzipKb} kB gzip (budget ${budget.entryGzipKb})`
+      : `Entry chunk (${entryName}): ${entryGzipKb} kB gzip (informational)`,
+  );
   if (budget.initialLoadGzipKb != null) {
     console.log(
       `Initial load (entry + preloads): ${initialLoadGzipKb} kB gzip (budget ${budget.initialLoadGzipKb})`,


### PR DESCRIPTION
## Problem

`main` CI is red — the **only** failing check is the `bundle` gate. It hard-gated on the **entry chunk alone**, which CI reports at **193.2 kB gzip** (budget 130).

This is **not a real regression**. The budget was calibrated on a stale local build (vite **8.0.8**, entry 101.5 kB), but the lockfile + CI use vite **8.1.3**, and the two rolldown chunkers split modules differently between the entry chunk and the first shared chunk (`ErrorRetry-*.js`) — with **no change to what the browser fetches on first paint**:

| Metric | vite 8.0.8 | vite 8.1.3 (CI) | Budget |
| --- | ---: | ---: | ---: |
| Entry chunk **alone** | 101.5 kB | 193.2 kB | 130 ✗ |
| **Initial load** (first-paint JS) | 553 kB | **544.6 kB** | 580 ✓ |
| **Total JS** | 591.3 kB | **582.4 kB** | 615 ✓ |

## Fix

- `check-bundle-size.mjs`: the entry-chunk breach only fires if a budget is explicitly set; otherwise the entry chunk is **reported informationally**. Headroom + markdown/default output tolerate an absent entry budget.
- `bundle-budget.json`: drop `entryGzipKb`; keep the **portable** gates `initialLoadGzipKb: 580` and `totalJsGzipKb: 615` (both pass with ~33–35 kB headroom on 8.1.3). Comment explains why entry-alone is non-portable.

No source / `vite.config.ts` change — the code-split is doing its job; this is purely gate calibration.

## Verification

Reproduced CI locally (`npm ci` → vite 8.1.3, rebuild): `node scripts/check-bundle-size.mjs` → **exit 0** (entry informational, initial-load + total green). `npm run typecheck` clean · `npm test` 245/245.

🤖 Generated with [Claude Code](https://claude.com/claude-code)